### PR TITLE
Version 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-extension-provider",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-extension-provider",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "A module for allowing a WebExtension to access the web3 provider from an installed MetaMask instance.",
   "main": "index.js",
   "type": "index.d.ts",


### PR DESCRIPTION
Republishing what was 2.0.1 as 3.0.0 because it had a breaking change,
and was not compatible with MetaMask versions before 9.
Will then deprecate 2.0.1, as it was not actually a patch release.