### PR TITLE
chore: npm 9, lockfile version 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,44 @@
 {
   "name": "metamask-extension-provider",
   "version": "3.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "@babel/runtime": {
+  "packages": {
+    "": {
+      "name": "metamask-extension-provider",
+      "version": "3.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@metamask/inpage-provider": "^8.0.3",
+        "detect-browser": "^5.3.0",
+        "extension-port-stream": "^2.0.0"
+      },
+      "devDependencies": {
+        "@babel/runtime": "^7.24.5",
+        "@metamask/ethjs": "^0.6.0"
+      },
+      "engines": {
+        "npm": ">=9"
+      }
+    },
+    "node_modules/@babel/runtime": {
       "version": "7.24.5",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.5.tgz",
       "integrity": "sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
-    "@metamask/ethjs": {
+    "node_modules/@metamask/ethjs": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@metamask/ethjs/-/ethjs-0.6.0.tgz",
       "integrity": "sha512-CNG3vsj3ArhEhpkEK6+yUDbSgOJCtaALf+XEZXFhYbgVHPsVkhj9hSd+LInhUMrq4ViHAR7MZVt2RCb2npqppg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@metamask/ethjs-contract": "^0.4.1",
         "@metamask/ethjs-filter": "^0.3.0",
         "@metamask/ethjs-provider-http": "^0.3.0",
@@ -30,110 +50,170 @@
         "ethjs-abi": "0.2.1",
         "js-sha3": "^0.9.2"
       },
-      "dependencies": {
-        "js-sha3": {
-          "version": "0.9.3",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.9.3.tgz",
-          "integrity": "sha512-BcJPCQeLg6WjEx3FE591wVAevlli8lxsxm9/FzV4HXkV49TmBH38Yvrpce6fjbADGMKFrBMGTqrVz3qPIZ88Gg==",
-          "dev": true
-        }
+      "engines": {
+        "node": ">=8.17.0",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.0.0"
       }
     },
-    "@metamask/ethjs-contract": {
+    "node_modules/@metamask/ethjs-contract": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@metamask/ethjs-contract/-/ethjs-contract-0.4.1.tgz",
       "integrity": "sha512-QU/SQ6ZUZYzxNo81VzHtyJoFb11gZCHk6tnMSNv1OgPCJui2DKsfgk+VIJHaarL9gUohYNDYkjnAvwafyKiJSA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@metamask/ethjs-filter": "^0.3.0",
         "@metamask/ethjs-util": "^0.3.0",
         "ethjs-abi": "^0.2.0",
         "js-sha3": "^0.9.2",
         "promise-to-callback": "^1.0.0"
       },
-      "dependencies": {
-        "js-sha3": {
-          "version": "0.9.3",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.9.3.tgz",
-          "integrity": "sha512-BcJPCQeLg6WjEx3FE591wVAevlli8lxsxm9/FzV4HXkV49TmBH38Yvrpce6fjbADGMKFrBMGTqrVz3qPIZ88Gg==",
-          "dev": true
-        }
+      "engines": {
+        "node": ">=8.17.0",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.0.0"
       }
     },
-    "@metamask/ethjs-filter": {
+    "node_modules/@metamask/ethjs-contract/node_modules/js-sha3": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.9.3.tgz",
+      "integrity": "sha512-BcJPCQeLg6WjEx3FE591wVAevlli8lxsxm9/FzV4HXkV49TmBH38Yvrpce6fjbADGMKFrBMGTqrVz3qPIZ88Gg==",
+      "dev": true
+    },
+    "node_modules/@metamask/ethjs-filter": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@metamask/ethjs-filter/-/ethjs-filter-0.3.0.tgz",
       "integrity": "sha512-uXTIsJXQhMylX/cs2Z5J4hVVLTajoWOw+dVwLjWt221HO/pwWATJSjpMYsdWQul0slLSLQMIYlFUGOtDxZkh+Q==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8.17.0",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.0.0"
+      }
     },
-    "@metamask/ethjs-format": {
+    "node_modules/@metamask/ethjs-format": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@metamask/ethjs-format/-/ethjs-format-0.3.0.tgz",
       "integrity": "sha512-Q0FhY/e7XYmP4y7qMhM3Fv86Z0kO+mont8BqBogDMOMvSa8bzjPy94XRKHarIcYICyCL9Kp2zGHVTuQR2J+JtA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@metamask/ethjs-util": "^0.3.0",
         "@metamask/number-to-bn": "^1.7.1",
         "bn.js": "^5.2.1",
         "ethjs-schema": "0.2.1",
         "is-hex-prefixed": "1.0.0",
         "strip-hex-prefix": "1.0.0"
+      },
+      "engines": {
+        "node": ">=8.17.0",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.0.0"
       }
     },
-    "@metamask/ethjs-provider-http": {
+    "node_modules/@metamask/ethjs-provider-http": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@metamask/ethjs-provider-http/-/ethjs-provider-http-0.3.0.tgz",
       "integrity": "sha512-t4dHYDSXMJZc46SwTgbcXYWs4uzb311dzHe730ZKR0BiPbos8oc9+toMw43w+ziqymhAdIbYIXo3hXX3dw7tOw==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "xhr2": "0.2.1"
+      },
+      "engines": {
+        "node": ">=8.17.0",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.0.0"
       }
     },
-    "@metamask/ethjs-query": {
+    "node_modules/@metamask/ethjs-query": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/@metamask/ethjs-query/-/ethjs-query-0.7.1.tgz",
       "integrity": "sha512-ctyFom36AHq/6TW1CECOB0m/ESxVD24szkeLXFOnJ/5mlICA5bUEC62AUedAEF8pqVgbxhDkr1gwEwXn6W/j0Q==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@metamask/ethjs-format": "^0.3.0",
         "@metamask/ethjs-rpc": "^0.4.0",
         "promise-to-callback": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.17.0",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.0.0"
       }
     },
-    "@metamask/ethjs-rpc": {
+    "node_modules/@metamask/ethjs-rpc": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@metamask/ethjs-rpc/-/ethjs-rpc-0.4.0.tgz",
       "integrity": "sha512-lKTQfIXOyWsbGf9QqGaA6RnLcyvEeBPk5kAs1dXfWDpWL8+9TE0PbhPDQGjfn5Z9MFWEelJ2HD251wk0jAxD2A==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "promise-to-callback": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.17.0",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.0.0"
       }
     },
-    "@metamask/ethjs-unit": {
+    "node_modules/@metamask/ethjs-unit": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@metamask/ethjs-unit/-/ethjs-unit-0.3.0.tgz",
       "integrity": "sha512-HZtg69ODXYS9+ovKUYofZuIAwq4fc2/MGazD4vBQRKWMhPu4ySdmgR0EuzbxEK4uhr18KA4pbL+mCYjyjGxY7w==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@metamask/number-to-bn": "^1.7.1",
         "bn.js": "^5.2.1"
+      },
+      "engines": {
+        "node": ">=8.17.0",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.0.0"
       }
     },
-    "@metamask/ethjs-util": {
+    "node_modules/@metamask/ethjs-util": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@metamask/ethjs-util/-/ethjs-util-0.3.0.tgz",
       "integrity": "sha512-BXOEPmzDAzbsizZSW/wRW+58FBfj3K/1/jd7pZ9mKCOwlUCqhv8nyiiGTXQItRo+PH+GeuRGiR/IxuvSfw3CnQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "is-hex-prefixed": "1.0.0",
         "strip-hex-prefix": "1.0.0"
+      },
+      "engines": {
+        "node": ">=8.17.0",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.0.0"
       }
     },
-    "@metamask/inpage-provider": {
+    "node_modules/@metamask/ethjs/node_modules/js-sha3": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.9.3.tgz",
+      "integrity": "sha512-BcJPCQeLg6WjEx3FE591wVAevlli8lxsxm9/FzV4HXkV49TmBH38Yvrpce6fjbADGMKFrBMGTqrVz3qPIZ88Gg==",
+      "dev": true
+    },
+    "node_modules/@metamask/inpage-provider": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/@metamask/inpage-provider/-/inpage-provider-8.0.3.tgz",
       "integrity": "sha512-pj9tGNoS1edohuRJzxOuILRqRrQTdgu5mJwMwa9wuOZIMQLFZtr3g2T6vayPBwoNkE1FzLhs/osUqaVQDRfDvQ==",
-      "requires": {
+      "deprecated": "Package renamed to @metamask/providers",
+      "dependencies": {
         "@metamask/object-multiplex": "^1.1.0",
         "@metamask/safe-event-emitter": "^2.0.0",
         "eth-rpc-errors": "^4.0.2",
@@ -144,209 +224,233 @@
         "pump": "^3.0.0"
       }
     },
-    "@metamask/number-to-bn": {
+    "node_modules/@metamask/number-to-bn": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@metamask/number-to-bn/-/number-to-bn-1.7.1.tgz",
       "integrity": "sha512-qCN+Au4amvcVii2LdOJNndYhdmk5Lk9tlStJhKpZ8tGeYQDJTghqYXJuSUVPHvfl6FUfKY1i1Or2j2EbnEerSQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "bn.js": "5.2.1",
         "strip-hex-prefix": "1.0.0"
+      },
+      "engines": {
+        "node": ">=8.17.0",
+        "npm": ">=6"
       }
     },
-    "@metamask/object-multiplex": {
+    "node_modules/@metamask/object-multiplex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@metamask/object-multiplex/-/object-multiplex-1.1.0.tgz",
       "integrity": "sha512-ImDw5+NdO5qnzmK/rpSlPmQMQm6HIC6wAHdR9nBaDK8TpeuRik5H8DCUcoNrxSeUAk1iHwchZ03lpZu6mZfrdw==",
-      "requires": {
+      "dependencies": {
         "end-of-stream": "^1.4.4",
         "once": "^1.4.0",
         "readable-stream": "^2.3.3"
       }
     },
-    "@metamask/safe-event-emitter": {
+    "node_modules/@metamask/safe-event-emitter": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz",
       "integrity": "sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q=="
     },
-    "bn.js": {
+    "node_modules/bn.js": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
       "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
       "dev": true
     },
-    "core-util-is": {
+    "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
-    "detect-browser": {
+    "node_modules/detect-browser": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
       "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
     },
-    "end-of-stream": {
+    "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "requires": {
+      "dependencies": {
         "once": "^1.4.0"
       }
     },
-    "eth-rpc-errors": {
+    "node_modules/eth-rpc-errors": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/eth-rpc-errors/-/eth-rpc-errors-4.0.2.tgz",
       "integrity": "sha512-n+Re6Gu8XGyfFy1it0AwbD1x0MUzspQs0D5UiPs1fFPCr6WAwZM+vbIhXheBFrpgosqN9bs5PqlB4Q61U/QytQ==",
-      "requires": {
+      "dependencies": {
         "fast-safe-stringify": "^2.0.6"
       }
     },
-    "ethjs-abi": {
+    "node_modules/ethjs-abi": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.2.1.tgz",
       "integrity": "sha1-4KepOn6BFjqUR3utVu3lJKtt5TM=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "bn.js": "4.11.6",
         "js-sha3": "0.5.5",
         "number-to-bn": "1.7.0"
       },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-          "dev": true
-        }
+      "engines": {
+        "node": ">=6.5.0",
+        "npm": ">=3"
       }
     },
-    "ethjs-schema": {
+    "node_modules/ethjs-abi/node_modules/bn.js": {
+      "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+      "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==",
+      "dev": true
+    },
+    "node_modules/ethjs-schema": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/ethjs-schema/-/ethjs-schema-0.2.1.tgz",
       "integrity": "sha512-DXd8lwNrhT9sjsh/Vd2Z+4pfyGxhc0POVnLBUfwk5udtdoBzADyq+sK39dcb48+ZU+2VgtwHxtGWnLnCfmfW5g==",
       "dev": true
     },
-    "extension-port-stream": {
+    "node_modules/extension-port-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/extension-port-stream/-/extension-port-stream-2.0.0.tgz",
       "integrity": "sha512-7ju8jisPXY8w8UiUczF61hRN6bpx/YTZYU9J901GnEqu7vQnweMAwS30k+SgXCcY9S38Zno+fhuu1iaxd+0swg=="
     },
-    "fast-deep-equal": {
+    "node_modules/fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
-    "fast-safe-stringify": {
+    "node_modules/fast-safe-stringify": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
       "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
-    "inherits": {
+    "node_modules/inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
-    "is-fn": {
+    "node_modules/is-fn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fn/-/is-fn-1.0.0.tgz",
       "integrity": "sha1-lUPV3nvPWwiiLsiiC65uKG1RDYw=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "is-hex-prefixed": {
+    "node_modules/is-hex-prefixed": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
       "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=6.5.0",
+        "npm": ">=3"
+      }
     },
-    "is-stream": {
+    "node_modules/is-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "engines": {
+        "node": ">=8"
+      }
     },
-    "isarray": {
+    "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
-    "js-sha3": {
+    "node_modules/js-sha3": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
-      "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko=",
+      "integrity": "sha512-yLLwn44IVeunwjpDVTDZmQeVbB0h+dZpY2eO68B/Zik8hu6dH+rKeLxwua79GGIvW6xr8NBAcrtiUbYrTjEFTA==",
       "dev": true
     },
-    "json-rpc-engine": {
+    "node_modules/json-rpc-engine": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-6.1.0.tgz",
       "integrity": "sha512-NEdLrtrq1jUZyfjkr9OCz9EzCNhnRyWtt1PAnvnhwy6e8XETS0Dtc+ZNCO2gvuAoKsIn2+vCSowXTYE4CkgnAQ==",
-      "requires": {
+      "dependencies": {
         "@metamask/safe-event-emitter": "^2.0.0",
         "eth-rpc-errors": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
-    "json-rpc-middleware-stream": {
+    "node_modules/json-rpc-middleware-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-rpc-middleware-stream/-/json-rpc-middleware-stream-3.0.0.tgz",
       "integrity": "sha512-JmZmlehE0xF3swwORpLHny/GvW3MZxCsb2uFNBrn8TOqMqivzCfz232NSDLLOtIQlrPlgyEjiYpyzyOPFOzClw==",
-      "requires": {
+      "dependencies": {
         "@metamask/safe-event-emitter": "^2.0.0",
         "readable-stream": "^2.3.3"
       }
     },
-    "number-to-bn": {
+    "node_modules/number-to-bn": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
       "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "bn.js": "4.11.6",
         "strip-hex-prefix": "1.0.0"
       },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-          "dev": true
-        }
+      "engines": {
+        "node": ">=6.5.0",
+        "npm": ">=3"
       }
     },
-    "once": {
+    "node_modules/number-to-bn/node_modules/bn.js": {
+      "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+      "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==",
+      "dev": true
+    },
+    "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
+      "dependencies": {
         "wrappy": "1"
       }
     },
-    "process-nextick-args": {
+    "node_modules/process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
-    "promise-to-callback": {
+    "node_modules/promise-to-callback": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/promise-to-callback/-/promise-to-callback-1.0.0.tgz",
       "integrity": "sha1-XSp0kBC/tn2WNZj805YHRqaP7vc=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "is-fn": "^1.0.0",
         "set-immediate-shim": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "pump": {
+    "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "requires": {
+      "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
     },
-    "readable-stream": {
+    "node_modules/readable-stream": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-      "requires": {
+      "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
         "isarray": "~1.0.0",
@@ -356,55 +460,65 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "regenerator-runtime": {
+    "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
       "dev": true
     },
-    "safe-buffer": {
+    "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
-    "set-immediate-shim": {
+    "node_modules/set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "string_decoder": {
+    "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
+      "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
-    "strip-hex-prefix": {
+    "node_modules/strip-hex-prefix": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
       "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "is-hex-prefixed": "1.0.0"
+      },
+      "engines": {
+        "node": ">=6.5.0",
+        "npm": ">=3"
       }
     },
-    "util-deprecate": {
+    "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
-    "wrappy": {
+    "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
-    "xhr2": {
+    "node_modules/xhr2": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.2.1.tgz",
       "integrity": "sha512-sID0rrVCqkVNUn8t6xuv9+6FViXjUVXq8H5rWOH2rz9fDNQEd4g0EA2XlcEdJXRz5BMEn4O1pJFdT+z4YHhoWw==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "url": "https://github.com/danfinlay/metamask-extension-provider/issues"
   },
   "homepage": "https://github.com/danfinlay/metamask-extension-provider#readme",
+  "engines": {
+    "npm": ">=9"
+  },
   "dependencies": {
     "@metamask/inpage-provider": "^8.0.3",
     "detect-browser": "^5.3.0",


### PR DESCRIPTION
- Upgrade `package-lock.json` schema from v1 to v3
- NPM minimum version 9 (supported down to nodejs v14)