### PR TITLE
fix: extension-port-stream require

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const { MetaMaskInpageProvider } = require('@metamask/inpage-provider')
-const PortStream = require('extension-port-stream')
+const PortStream = require('extension-port-stream').default
 const { detect } = require('detect-browser')
 const browser = detect()
 const config = require('./config.json')

--- a/sample-extension/bundle.js
+++ b/sample-extension/bundle.js
@@ -6,7 +6,7 @@ module.exports={
 
 },{}],2:[function(require,module,exports){
 const { MetaMaskInpageProvider } = require('@metamask/inpage-provider')
-const PortStream = require('extension-port-stream')
+const PortStream = require('extension-port-stream').default
 const { detect } = require('detect-browser')
 const browser = detect()
 const config = require('./config.json')


### PR DESCRIPTION
This fixes the import of `extension-port-stream` to work with `browserify`. Fixes error in sample.