### PR TITLE
fix(sample): non-colliding firefox application id

### DIFF
--- a/sample-extension/manifest.json
+++ b/sample-extension/manifest.json
@@ -21,7 +21,7 @@
   },
   "applications": {
     "gecko": {
-      "id": "webextension@metamask.io"
+      "id": "webextension-sample@metamask.io"
     }
   },
   "browser_action": {


### PR DESCRIPTION
`webextension@metamask.io` is the same ID as MetaMask Extension. This means the two can not be installed at the same time. This changes the ID to be different.