### PR TITLE
chore: update package version in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "metamask-extension-provider",
-      "version": "3.0.0",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "@metamask/inpage-provider": "^8.0.3",


### PR DESCRIPTION
- Follow-up to #41 

Updates the version field in `package-log.json`. 